### PR TITLE
Add UID to Shopify extension configuration

### DIFF
--- a/extensions/client-validation/shopify.extension.toml
+++ b/extensions/client-validation/shopify.extension.toml
@@ -9,6 +9,7 @@ api_version = "2024-07"
 type = "ui_extension"
 name = "client-validation"
 handle = "client-validation"
+uid = "86819c9b-e4f2-1eab-3a11-a68e00138fd457cb6248"
 
 # Controls where in Shopify your extension will be injected,
 # and the file that contains your extension’s source code. Learn more:


### PR DESCRIPTION
Add deterministic UID based on extension handle

Relates to: https://github.com/Shopify/shopify-dev/issues/65152

Purpose:
The uid field is now required in shopify.extension.toml files for all extensions. UIDs are generated deterministically from the handle to ensure consistent values and allow users to safely copy examples without replacing placeholders.